### PR TITLE
[DT-041385] Allow for Recipient Type to be Configurable

### DIFF
--- a/Decisions.Docusign/SendDocumentsForSigning.cs
+++ b/Decisions.Docusign/SendDocumentsForSigning.cs
@@ -210,6 +210,8 @@ namespace Decisions.Docusign
                                 UserName = ccEmail,
                                 Type = RecipientTypeCode.CarbonCopy,
                                 ID = recipientIndex.ToString(),
+                                RoutingOrder = 1,
+                                RoutingOrderSpecified = true
                             });
                             recipientIndex++;
                         }


### PR DESCRIPTION
Added RoutingOrder and RoutingOrderSpecified properties to the CC recipients in order for them to receive the same email as the signer recipients at the same time