### PR TITLE
[DT-041385] Allow for Recipient Type to be Configurable

### DIFF
--- a/Decisions.Docusign/DataTypes/RecipientTabMapping.cs
+++ b/Decisions.Docusign/DataTypes/RecipientTabMapping.cs
@@ -26,6 +26,9 @@ namespace Decisions.Docusign.DataTypes
 
         [DataMember]
         public SimpleAnchorTab[] AnchorStringTabs { get; set; }
+        
+        [DataMember]
+        public string[] CCRecipients { get; set; }
 
         public override string ToString()
         {

--- a/Decisions.Docusign/SendDocumentsForSigning.cs
+++ b/Decisions.Docusign/SendDocumentsForSigning.cs
@@ -178,7 +178,7 @@ namespace Decisions.Docusign
                                     DocumentID = GetIdentifierOrDefaultOneAsString(apt.DocumentId),
                                 });
                             }
-                        };
+                        }
                         // AnchorStringTabs
                         // Docusign will search the document for these string values and attach a Tab at that location.
                         if (rtm.AnchorStringTabs != null)
@@ -195,9 +195,27 @@ namespace Decisions.Docusign
                                     DocumentID = GetIdentifierOrDefaultOneAsString(ast.DocumentId),
                                 });
                             }
-                        };
+                        }
+                        
+                        // Add CC Recipients for current signer
+                        if (rtm.CCRecipients != null)
+                        {
+                            foreach (var ccRecipient in rtm.CCRecipients)
+                            {
+                                dsRecipients.Add(new Recipient
+                                {
+                                    Email = ccRecipient,
+                                    UserName = ccRecipient,
+                                    Type = RecipientTypeCode.CarbonCopy,
+                                    ID = (++recipientIndex).ToString(),
+                                    RoutingOrder = (ushort)routingOrder,
+                                    RoutingOrderSpecified = true
+                                });
+                            }
+                        }
+                        
                         recipientIndex++;
-                    };
+                    }
                     
                     // Add CC recipients
                     if (cc != null)


### PR DESCRIPTION
Added new CC Recipients input when configuring Recipients input 
Each Signer recipient can have their own list of CC Recipients