### PR TITLE
[DT-045265] FR: Add New Inputs To Send Document For Signing Step In DocuSign Module

### DIFF
--- a/Decisions.Docusign/SendDocumentsForSigning.cs
+++ b/Decisions.Docusign/SendDocumentsForSigning.cs
@@ -321,6 +321,9 @@ namespace Decisions.Docusign
                 IDCheckConfigurationName = rtm.IDCheckConfigurationName
             };
 
+            if (rtm.RecipientSignatureProviders == null)
+                return recipient;
+
             List<RecipientSignatureProvider> rsps = new List<RecipientSignatureProvider>();
             foreach (SimpleRecipientSignatureProvider rsp in rtm.RecipientSignatureProviders)
             {

--- a/Module.Build.json
+++ b/Module.Build.json
@@ -13,7 +13,7 @@
       "ObjectsToImport": null,
       "MsSqlScript": null
     },
-    "Version": "9.10.0",
+    "Version": "9.14.0",
     "ImagePath": "./image.png",
     "Description": "This module has Flow Steps that will let you send a document to Docusign so that Docusign can capture electronic signatures and initials.  The steps are limited to using X,Y position in the document to mark where to sign, or using Docusign's \"Tag\" ability to indicate areas in the document that require signatures.  In Decisions it is a common pattern to send the document out, through Docusign, for signatures and then use the \"Wait on External Event\" step to monitor Docusign, watching for the document to be fully executed before pulling it back into the workflow.  An example of this workflow is available on our documentation site."
 }


### PR DESCRIPTION
Adding null check before looping through signature providers. Was throwing null reference error when the list wasn't set